### PR TITLE
:ambulance: Revert accidental testing commit

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@
 rm -rf assets/dist
 
 # Decrypt production settings
-#openssl aes-256-cbc -K $encrypted_8c964e5c4b48_key -iv $encrypted_8c964e5c4b48_iv -in secure/prod.py.enc -out reverie/settings/prod.py -d
+openssl aes-256-cbc -K $encrypted_8c964e5c4b48_key -iv $encrypted_8c964e5c4b48_iv -in secure/prod.py.enc -out reverie/settings/prod.py -d
 
 # Build production bundle
 ASSET_PATH="https://cdn.reverie.oneirism.co/prod/static/bundles/" yarn bundle


### PR DESCRIPTION
File decryption was uncommented for local testing. It is required for CI deployment.

Safeguards will be required long-term.